### PR TITLE
Use the year when determining if a date is today

### DIFF
--- a/src/com/example/android/monthcalendarwidget/MonthCalendarWidget.java
+++ b/src/com/example/android/monthcalendarwidget/MonthCalendarWidget.java
@@ -135,6 +135,7 @@ public class MonthCalendarWidget extends AppWidgetProvider {
 
         Calendar cal = Calendar.getInstance();
         int today = cal.get(Calendar.DAY_OF_YEAR);
+        int todayYear = cal.get(Calendar.YEAR);
         int thisMonth;
         if (!mini) {
             thisMonth = sp.getInt(PREF_MONTH, cal.get(Calendar.MONTH));
@@ -173,7 +174,8 @@ public class MonthCalendarWidget extends AppWidgetProvider {
             RemoteViews rowRv = new RemoteViews(context.getPackageName(), R.layout.row_week);
             for (int day = 0; day < 7; day++) {
                 boolean inMonth = cal.get(Calendar.MONTH) == thisMonth;
-                boolean isToday = inMonth && cal.get(Calendar.DAY_OF_YEAR) == today;
+                boolean inYear  = cal.get(Calendar.YEAR) == todayYear;
+                boolean isToday = inYear && inMonth && (cal.get(Calendar.DAY_OF_YEAR) == today);
 
                 boolean isFirstOfMonth = cal.get(Calendar.DAY_OF_MONTH) == 1;
                 int cellLayoutResId = R.layout.cell_day;


### PR DESCRIPTION
`isToday` should only be `true` if all of the year, month, and day of the week are the same. This way today's date isn't being highlighted in future years (e.g. September 2014, 2015, etc).
